### PR TITLE
[김성준] sprint3 

### DIFF
--- a/login.css
+++ b/login.css
@@ -80,7 +80,7 @@ input[type="text"] {
   border-radius: 10px;
   border: 1px solid #e0e0e0;
   background-color: #f6f7f9;
-  font-size: 14px;
+  font-size: 16px;
 }
 
 /* 비밀번호 필드에 눈 아이콘 */
@@ -148,10 +148,78 @@ input[type="text"] {
   font-style: normal;
   font-weight: 500;
   line-height: 24px;
+  margin-top: 12px;
 }
 
 .signup-text a {
   color: #007bff;
   text-decoration: none;
   font-weight: 500;
+}
+
+input.error {
+  border: 1px solid red;
+}
+
+.error-message {
+  color: red;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.login-button {
+  background-color: #8b99a6; /* 비활성시 */
+  color: white;
+  border: none;
+  padding: 10px;
+  width: 100%;
+  transition: background-color 0.3s;
+}
+
+.login-button.enabled {
+  background-color: #3396ff; /* 활성시 파란색 */
+  cursor: pointer;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+}
+
+/* 어두운 배경 */
+.modal-backdrop {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+/* 중앙 모달 창 */
+.modal-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  padding: 24px 20px;
+  border-radius: 10px;
+  text-align: center;
+  width: 280px;
+}
+
+.modal-content p {
+  margin-bottom: 16px;
+}
+
+.modal-close {
+  background-color: #3396ff;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
 }

--- a/login.html
+++ b/login.html
@@ -5,28 +5,53 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>판다마켓</title>
   <link rel="stylesheet" href="login.css" />
-  <link rel="icon" href="img/logoimg.png">
+  <link rel="icon" href="img/logoimg.png" />
+  <style>
+    input.error {
+      border: 1px solid red;
+    }
+    .error-message {
+      color: red;
+      font-size: 13px;
+      margin-top: 4px;
+    }
+    .login-button {
+      background-color: #8b99a6;
+      color: white;
+      border: none;
+      padding: 10px;
+      width: 100%;
+      cursor: not-allowed;
+      transition: background-color 0.3s;
+    }
+    .login-button.enabled {
+      background-color: #3396ff;
+      cursor: pointer;
+    }
+  </style>
 </head>
 <body>
   <div class="container">
     <div class="login-box">
       <a href="sprint1.html"><img src="img/logo.png" alt="로고" class="logo" /></a>
 
-      <form class="login-form">
+      <form id="login-form" class="login-form">
         <div class="form-group">
           <label for="email">이메일</label>
           <input type="email" id="email" placeholder="이메일을 입력해주세요" required />
+          <p id="email-error" class="error-message"></p>
         </div>
 
         <div class="form-group">
           <label for="password">비밀번호</label>
           <div class="password-wrapper">
             <input type="password" id="password" placeholder="비밀번호를 입력해주세요" required />
-            <span class="toggle-visibility"><img src="img/blind.png"></span>
+            <span class="toggle-visibility"><img src="img/blind.png" alt="toggle" /></span>
           </div>
+          <p id="password-error" class="error-message"></p>
         </div>
 
-        <button type="submit" class="login-button">로그인</button>
+        <button type="submit" class="login-button" disabled>로그인</button>
       </form>
 
       <div class="social-login">
@@ -44,5 +69,7 @@
       </p>
     </div>
   </div>
+
+  <script src="login.js"></script>
 </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,118 @@
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: "codeit101!" },
+  { email: 'codeit2@codeit.com', password: "codeit202!" },
+  { email: 'codeit3@codeit.com', password: "codeit303!" },
+  { email: 'codeit4@codeit.com', password: "codeit404!" },
+  { email: 'codeit5@codeit.com', password: "codeit505!" },
+  { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
+const emailInput = document.getElementById('email');
+const passwordInput = document.getElementById('password');
+const loginButton = document.querySelector('.login-button');
+const visibilityToggle = document.querySelector('.toggle-visibility');
+
+const emailError = document.getElementById('email-error');
+const passwordError = document.getElementById('password-error');
+
+function showError(input, errorElement, message) {
+  input.classList.add('error');
+  errorElement.innerText = message;
+}
+
+function clearError(input, errorElement) {
+  input.classList.remove('error');
+  errorElement.innerText = '';
+}
+
+function validateEmail() {
+  const value = emailInput.value.trim();
+  clearError(emailInput, emailError);
+
+  if (!value) {
+    showError(emailInput, emailError, '이메일을 입력해주세요.');
+    return false;
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(value)) {
+    showError(emailInput, emailError, '잘못된 이메일 형식입니다.');
+    return false;
+  }
+
+  return true;
+}
+
+function validatePassword() {
+  const value = passwordInput.value.trim();
+  clearError(passwordInput, passwordError);
+
+  if (!value) {
+    showError(passwordInput, passwordError, '비밀번호를 입력해주세요.');
+    return false;
+  }
+  return true;
+}
+
+function updateButtonState() {
+  const emailValid = emailInput.value.trim() !== '';
+  const passwordValid = passwordInput.value.trim() !== '';
+
+  if (emailValid && passwordValid) {
+    loginButton.disabled = false;
+    loginButton.classList.add('enabled');
+  } else {
+    loginButton.disabled = true;
+    loginButton.classList.remove('enabled');
+  }
+}
+
+emailInput.addEventListener('input', () => {
+  validateEmail();
+  updateButtonState();
+});
+
+passwordInput.addEventListener('input', () => {
+  validatePassword();
+  updateButtonState();
+});
+
+// 비밀번호 보기/숨기기 토글
+visibilityToggle.addEventListener('click', () => {
+  if (passwordInput.type === 'password') {
+    passwordInput.type = 'text';
+    visibilityToggle.innerHTML = '<img src="img/blind.png" alt="숨기기">';
+  } else {
+    passwordInput.type = 'password';
+    visibilityToggle.innerHTML = '<img src="img/blind.png" alt="보기">';
+  }
+});
+
+document.getElementById('login-form').addEventListener('submit', (e) => {
+  e.preventDefault();
+
+  // 유효성 재검사
+  if (!validateEmail() || !validatePassword()) {
+    updateButtonState();
+    return;
+  }
+
+  const email = emailInput.value.trim();
+  const password = passwordInput.value;
+
+  // USER_DATA에서 이메일로 검색
+  const user = USER_DATA.find(user => user.email === email);
+
+  if (!user || user.email !== email){
+    alert('이메일이 일치하지 않습니다.');
+    return;
+  }
+
+  if (!user || user.password !== password) {
+    alert('비밀번호가 일치하지 않습니다.');
+    return;
+  }
+
+  // 로그인 성공 시 /items로 이동
+  window.location.href = '/items';
+});

--- a/register.html
+++ b/register.html
@@ -3,7 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>판다마켓</title>
+  <title>회원가입 - 판다마켓</title>
+  <meta property="og:title" content="판다마켓">
+  <meta property="og:description" content="일상에서 모든 물건을 거래해보세요">
+  <meta property="og:image" content="https://example.com/image.png">
+  <meta property="og:url" content="https://pandamarket.com">
   <link rel="stylesheet" href="login.css" />
   <link rel="icon" href="img/logoimg.png">
 </head>
@@ -15,47 +19,39 @@
       <form class="login-form">
         <div class="form-group">
           <label for="email">이메일</label>
-          <input type="email" id="email" placeholder="이메일을 입력해주세요" required />
+          <input type="email" id="email" placeholder="이메일을 입력해주세요" />
         </div>
 
         <div class="form-group">
           <label for="nickname">닉네임</label>
-          <input type="text" id="nickname" placeholder="닉네임을 입력해주세요" required />
+          <input type="text" id="nickname" placeholder="닉네임을 입력해주세요" />
         </div>
 
         <div class="form-group">
           <label for="password">비밀번호</label>
           <div class="password-wrapper">
-            <input type="password" id="password" placeholder="비밀번호를 입력해주세요" required />
+            <input type="password" id="password" placeholder="비밀번호를 입력해주세요" />
             <span class="toggle-visibility"><img src="img/blind.png"></span>
           </div>
         </div>
 
         <div class="form-group">
-          <label for="password">비밀번호 확인</label>
+          <label for="confirm-password">비밀번호 확인</label>
           <div class="password-wrapper">
-            <input type="password" id="password" placeholder="비밀번호를 다시 입력해주세요" required />
+            <input type="password" id="confirm-password" placeholder="비밀번호를 다시 입력해주세요" />
             <span class="toggle-visibility"><img src="img/blind.png"></span>
           </div>
         </div>
 
-        <button type="submit" class="login-button">로그인</button>
+        <button type="submit" class="login-button" disabled>회원가입</button>
       </form>
-
-      <div class="social-login">
-        <div class="social-box">
-           <p class="social-title">간편 로그인하기</p>
-           <div>
-          <a href="/"><img src="img/google.png" alt="구글" /></a>
-          <a href="/"><img src="img/kakao.png" alt="카카오" /></a>
-          </div>
-        </div>
-      </div>
 
       <p class="signup-text">
         이미 회원이신가요? <a href="login.html">로그인</a>
       </p>
     </div>
   </div>
+
+  <script src="register.js"></script>
 </body>
 </html>

--- a/register.js
+++ b/register.js
@@ -1,0 +1,176 @@
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: "codeit101!" },
+  { email: 'codeit2@codeit.com', password: "codeit202!" },
+  { email: 'codeit3@codeit.com', password: "codeit303!" },
+  { email: 'codeit4@codeit.com', password: "codeit404!" },
+  { email: 'codeit5@codeit.com', password: "codeit505!" },
+  { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
+const emailInput = document.getElementById('email');
+const nicknameInput = document.getElementById('nickname');
+const passwordInput = document.getElementById('password');
+const confirmInput = document.getElementById('confirm-password');
+const registerButton = document.querySelector('.login-button');
+const visibilityToggles = document.querySelectorAll('.toggle-visibility');
+
+function showError(input, message) {
+  removeError(input);
+  input.style.border = '1px solid red';
+  const error = document.createElement('p');
+  error.className = 'error-message';
+  error.style.color = 'red';
+  error.style.fontSize = '13px';
+  error.style.marginTop = '4px';
+  error.innerText = message;
+  input.parentNode.appendChild(error);
+}
+
+function removeError(input) {
+  input.style.border = '';
+  const error = input.parentNode.querySelector('.error-message');
+  if (error) {
+    error.remove();
+  }
+}
+
+function validateEmail() {
+  const value = emailInput.value.trim();
+  removeError(emailInput);
+
+  if (!value) {
+    showError(emailInput, '이메일을 입력해주세요.');
+    return false;
+  }
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(value)) {
+    showError(emailInput, '잘못된 이메일 형식입니다.');
+    return false;
+  }
+  return true;
+}
+
+function validatePassword() {
+  const value = passwordInput.value.trim();
+  removeError(passwordInput);
+
+  if (!value) {
+    showError(passwordInput, '비밀번호를 입력해주세요.');
+    return false;
+  }
+  if (value.length < 8) {
+    showError(passwordInput, '비밀번호를 8자 이상 입력해주세요.');
+    return false;
+  }
+  return true;
+}
+
+function validateConfirmPassword() {
+  const value = confirmInput.value.trim();
+  removeError(confirmInput);
+
+  if (!value) {
+    showError(confirmInput, '비밀번호를 다시 입력해주세요.');
+    return false;
+  }
+  if (value !== passwordInput.value) {
+    showError(confirmInput, '비밀번호가 일치하지 않습니다.');
+    return false;
+  }
+  return true;
+}
+
+function validateNickname() {
+  const value = nicknameInput.value.trim();
+  removeError(nicknameInput);
+
+  if (!value) {
+    showError(nicknameInput, '닉네임을 입력해주세요.');
+    return false;
+  }
+  return true;
+}
+
+function updateButtonState() {
+  const isValid =
+    validateEmail() &&
+    validateNickname() &&
+    validatePassword() &&
+    validateConfirmPassword();
+
+  registerButton.disabled = !isValid;
+  registerButton.style.backgroundColor = isValid ? '#3396ff' : '#8b99a6';
+
+  return isValid; 
+}
+
+emailInput.addEventListener('blur', validateEmail);
+passwordInput.addEventListener('blur', validatePassword);
+confirmInput.addEventListener('blur', validateConfirmPassword);
+nicknameInput.addEventListener('blur', validateNickname);
+
+document.querySelectorAll('input').forEach((input) => {
+  input.addEventListener('input', updateButtonState);
+});
+
+// 비밀번호 보기/숨기기
+visibilityToggles.forEach((toggle) => {
+  toggle.addEventListener('click', () => {
+    const input = toggle.previousElementSibling;
+    if (input.type === 'password') {
+      input.type = 'text';
+      toggle.innerHTML = '<img src="img/show.png">';
+    } else {
+      input.type = 'password';
+      toggle.innerHTML = '<img src="img/show.png">';
+    }
+  });
+});
+
+// 모달 생성
+function showModal(message) {
+  const modal = document.createElement('div');
+  modal.className = 'modal';
+  modal.innerHTML = `
+    <div class="modal-backdrop"></div>
+    <div class="modal-content">
+      <p>${message}</p>
+      <button class="modal-close">확인</button>
+    </div>
+  `;
+  document.body.appendChild(modal);
+  document.querySelector('.modal-close').addEventListener('click', () => {
+    modal.remove();
+  });
+}
+
+// 회원가입 제출
+registerButton.addEventListener('click', (e) => {
+  e.preventDefault();
+
+  const isValid =
+    validateEmail() &&
+    validateNickname() &&
+    validatePassword() &&
+    validateConfirmPassword();
+
+  if (!isValid) return;
+
+  const email = emailInput.value.trim();
+
+  const isDuplicate = USER_DATA.find((user) => user.email === email);
+
+  if (isDuplicate) {
+    showModal('사용 중인 이메일입니다');
+  } else {
+    showModal('회원가입이 완료되었습니다!');
+
+    // 버튼을 다시 눌러서 중복 실행되지 않도록 잠시 비활성화
+    registerButton.disabled = true;
+
+    // 1.5초 후 페이지 이동
+    setTimeout(() => {
+      window.location.href = 'login.html';
+    }, 1500);
+  }
+});


### PR DESCRIPTION
## 요구사항

### 기본

기본 요구사항
공통

[o] Github에 스프린트 미션 PR을 만들어 주세요.
로그인, 회원가입 페이지 공통

[o] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
[o] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
[o] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
[o ] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
[o ] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
[o ] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
[o ] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
[o ] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다
로그인 페이지
[ ] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.
회원가입

[ ] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

### 심화
[ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.
[ ] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
[ ] 주소와 이미지는 자유롭게 설정하세요.
GURU
[ ] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.
랜딩 페이지

[ ] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 744px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 743px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다
[ ] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
[ ] Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
[o] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.
[ ] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
[ ] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.
로그인, 회원가입 페이지 공통

[ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
[ ] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
[ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
[ ] 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
[ ] 비밀번호 및 비밀번호 확인 입력란에 눈 모양 아이콘 클릭 시 비밀번호 표시/숨기기 토글이 가능합니다. 기본 상태는 비밀번호 숨김으로 설정합니다.

## 스크린샷

![image](이미지url)

## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
